### PR TITLE
Arreglado endpoint "/nuevoUsuarioCreacion/esRepetido/"

### DIFF
--- a/demo/src/main/java/com/example/demo/config/UsuarioService.java
+++ b/demo/src/main/java/com/example/demo/config/UsuarioService.java
@@ -40,7 +40,7 @@ public class UsuarioService {
     }
 
     public boolean esNombreRepetido(String nombre){
-        if(obtenerUsuarioConectado().getNombre().equals(nombre)) return false; //Si el usuario envía su propio nombre, no se impedirá la validación
+        // if(obtenerUsuarioConectado().getNombre().equals(nombre)) return false; //Si el usuario envía su propio nombre, no se impedirá la validación
         if(contrataService.esNombreRepetido(nombre)) return true;
         else if(buscaService.esNombreRepetido(nombre)) return true;
         else if(adminService.esNombreRepetido(nombre)) return true;

--- a/demo/src/main/java/com/example/demo/controllers/nuevoUsuario/NuevoUsuarioApi.java
+++ b/demo/src/main/java/com/example/demo/controllers/nuevoUsuario/NuevoUsuarioApi.java
@@ -20,9 +20,8 @@ public class NuevoUsuarioApi {
     //Este es el mapeado con el que debería enlazar validarUsuario.js
     @GetMapping("/esRepetido/{nombre}")
     public ResponseEntity<Boolean> isUsernameRepeated(@PathVariable String nombre){
-        boolean esRepetido = usuarioService.esNombreRepetido(nombre);
-        //Este método comprueba si el nombre es repetido o no
-        return new ResponseEntity<>(esRepetido,HttpStatus.OK);
-        //Devuelve el resultado
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(usuarioService.esNombreRepetido(nombre));
     }
 }

--- a/demo/src/main/java/com/example/demo/services/usuarios/AdminServiceImpl.java
+++ b/demo/src/main/java/com/example/demo/services/usuarios/AdminServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.demo.services.usuarios;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -71,6 +72,7 @@ public class AdminServiceImpl implements AdminService{
     @Override
     public Admin obtenerAdminConectado() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth instanceof AnonymousAuthenticationToken) return null;
         Admin admin = obtenerPorNombre(auth.getName());
         return admin;
     }

--- a/demo/src/main/java/com/example/demo/services/usuarios/BuscaServiceImpl.java
+++ b/demo/src/main/java/com/example/demo/services/usuarios/BuscaServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.demo.services.usuarios;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -82,6 +83,7 @@ public class BuscaServiceImpl implements BuscaService{
     @Override
     public Busca obtenerBuscaConectado() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth instanceof AnonymousAuthenticationToken) return null;
         Busca busca = obtenerPorNombre(auth.getName());
         return busca;
     }

--- a/demo/src/main/java/com/example/demo/services/usuarios/ContrataServiceImpl.java
+++ b/demo/src/main/java/com/example/demo/services/usuarios/ContrataServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -88,6 +89,7 @@ public class ContrataServiceImpl implements ContrataService{
     @Override
     public Contrata obtenerContrataConectado() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth instanceof AnonymousAuthenticationToken) return null;
         Contrata contrata = obtenerPorNombre(auth.getName());
         return contrata;
     }


### PR DESCRIPTION
Spring Secutiry estaba tapando una Excepción que ocurre al intentar consultar el nickname de un `AnonymousAuthenticationToken` (no tiene).

Es necesario chekear que no se este accediendo a un objeto de este tipo.

En `esNombreRepetido` se comento el chekeo del nombre de usuario contectado porque al final es más facil leer desde la base de datos, el resultado es identico pero así no se manejan posibles nulos.